### PR TITLE
Fix missing variable, add .editorconfig file and example React app

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+example/build
 package-lock.json
 *.log

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+function App() {
+  return <h1>JSX is working!</h1>
+}
+
+ReactDOM.render(<App />, document.getElementById('root'))
+

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "webpack && cp public/* build",
+    "start": "ecstatic build --port 3000"
+  },
+  "dependencies": {
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "devDependencies": {
+    "ecstatic": "^3.3.0",
+    "swc": "^1.0.0-beta.20",
+    "webpack": "^4.28.4",
+    "webpack-cli": "^3.2.1"
+  }
+}

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head>
+        <title>swc-loader example</title>
+        <script src="/bundle.js" async defer></script>
+    </head>
+    <body>
+        <div id="root"></div>
+    </body>
+</html>

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const path = require('path')
+
+module.exports = {
+  mode: 'development',
+  entry: path.join(__dirname, 'index.js'),
+  output: {
+    path: path.join(__dirname, 'build'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /(node_modules|bower_components)/,
+        use: {
+          loader: require.resolve('..'),  // you would put swc-loader
+          options: {
+            jsc: {
+              transform: {
+                react: {
+                  pragma: 'React.createElement',
+                  pragmaFrag: 'React.Fragment',
+                  throwIfNamespace: true,
+                  development: false,
+                  useBuiltins: false
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ function makeLoader() {
     return function (source, inputSourceMap) {
         // Make the loader async
         const callback = this.async();
+        const filename = this.resourcePath;
 
         let loaderOptions = loaderUtils.getOptions(this) || {};
 


### PR DESCRIPTION
I hope this helps.

The example is surfacing a bug I found trying to use swc-loader. It's a very simple example, exactly what's in the docs, but it's failing with:

```
ERROR in ./index.js
Module build failed (from ../src/index.js):
Error: Error(InvalidKeyType("false"), State { next_error: None, backtrace: None })              
    at Object.transformSync (/home/fabio/devel/swc-loader/node_modules/swc/lib/index.js:11:39)  
    at Object.<anonymous> (/home/fabio/devel/swc-loader/src/index.js:60:32)                     
```

Any idea what may be causing it?