### PR TITLE
Introduce parseMap option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ function makeLoader() {
 
         // Remove loader related options
         delete programmaticOptions.sync;
+        delete programmaticOptions.parseMap;
         delete programmaticOptions.customize;
         delete programmaticOptions.cacheDirectory;
         delete programmaticOptions.cacheIdentifier;

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,10 @@ function makeLoader() {
         if (!programmaticOptions.inputSourceMap) {
             delete programmaticOptions.inputSourceMap;
         }
+
         const sync = programmaticOptions.sync;
+        const parseMap = programmaticOptions.parseMap;
+
         // Remove loader related options
         delete programmaticOptions.sync;
         delete programmaticOptions.customize;
@@ -67,11 +70,19 @@ function makeLoader() {
         try {
             if (sync) {
                 const output = swc.transformSync(source, programmaticOptions);
-                callback(null, output.code, output.map);
+                callback(
+                  null,
+                  output.code,
+                  parseMap ? JSON.parse(output.map) : output.map
+                );
             } else {
                 swc.transform(source, programmaticOptions).then(
                     output => {
-                        callback(null, output.code, output.map);
+                        callback(
+                          null,
+                          output.code, 
+                          parseMap ? JSON.parse(output.map) : output.map
+                        );
                     },
                     err => {
                         callback(err);


### PR DESCRIPTION
If, for any reason, you need to chain swc-loader with babel-loader, then `map` has to be parsed into an object to be accepted by babel.
