### PR TITLE
update(support Apple Silicon M1 arm64 architecture): update@swc/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
         "webpack": "^4.28.3"
     },
     "peerDependencies": {
-        "@swc/core": "^1.1.48",
+        "@swc/core": "^1.2.52",
         "webpack": ">=2"
     },
     "dependencies": {
-        "@swc/core": "^1.1.48",
+        "@swc/core": "^1.2.52",
         "loader-utils": "^2.0.0"
     }
 }


### PR DESCRIPTION
swc-core@1.1.48 does not support Apple Silicon M1.
So I have forked it and updated swc-core to 1.2.52, which I have tested on both M1 and intel chip mac, and do not find any problem at least for now.
Would you like to merge this commit to support other M1 users? or do you have any other thoughts?