### PR TITLE
feat: add Inject JSX helper before JSX and TSX files are processed by swc

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,36 @@ module: {
     ];
 }
 ```
+If you need to `customize a JSX helper`, you need to look like the example below, with vue3 as an example
+
+```js
+module: {
+    rules: [
+        {
+            test: /\.(tsx|jsx)$/,
+            exclude: /(node_modules|bower_components)/,
+            use: {
+                loader: "swc-loader",
+                options: {
+                    jsc: {
+                        parser: {
+                            syntax: "typescript"
+                        },
+                        transform: {
+                            react: {
+                                /** Use custom rendering functions, If you use the example of vue, it is */
+                                pragma: 'h',
+                                pragmaFrag: 'Fragment',
+                                jsxInject:`import { h, Fragment } from 'vue'`
+                            }
+                        },
+                    }
+                }
+            }
+        }
+    ];
+}
+```
 
 ## Configuration Reference
 Refer https://swc.rs/docs/configuring-swc

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,12 @@ function makeLoader() {
 
         let loaderOptions = loaderUtils.getOptions(this) || {};
 
+        const { jsc } = loaderOptions
+        // Inject JSX helper before JSX and TSX files are processed by swc
+        if (jsc.transform.react.jsxInject && /\.(?:j|t)sx\b/.test(filename)) {
+            source = jsxInject + ';' + source
+        }
+
         // Standardize on 'sourceMaps' as the key passed through to Webpack, so that
         // users may safely use either one alongside our default use of
         // 'this.sourceMap' below without getting error about conflicting aliases.
@@ -57,12 +63,13 @@ function makeLoader() {
         delete programmaticOptions.cacheIdentifier;
         delete programmaticOptions.cacheCompression;
         delete programmaticOptions.metadataSubscribers;
+        delete programmaticOptions.jsc.transform.react.jsxInject;
 
         // auto detect development mode
-        if (this.mode && programmaticOptions.jsc && programmaticOptions.jsc.transform 
-            && programmaticOptions.jsc.transform.react && 
+        if (this.mode && programmaticOptions.jsc && programmaticOptions.jsc.transform
+            && programmaticOptions.jsc.transform.react &&
             !Object.prototype.hasOwnProperty.call(programmaticOptions.jsc.transform.react, "development")) {
-                programmaticOptions.jsc.transform.react.development = this.mode === 'development'
+            programmaticOptions.jsc.transform.react.development = this.mode === 'development'
         }
 
         if (programmaticOptions.sourceMaps === "inline") {

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,13 @@ function makeLoader() {
         // Make the loader async
         const callback = this.async();
         const filename = this.resourcePath;
+        // Simply deep copy once to prevent the injection from being emptied
+        let loaderOptions = JSON.parse(JSON.stringify(loaderUtils.getOptions(this) || {}));
 
-        let loaderOptions = loaderUtils.getOptions(this) || {};
-
-        const { jsc } = loaderOptions
+        const { jsc } = loaderUtils.getOptions(this) || {};
         // Inject JSX helper before JSX and TSX files are processed by swc
         if (jsc.transform.react.jsxInject && /\.(?:j|t)sx\b/.test(filename)) {
-            source = jsxInject + ';' + source
+            source = jsc.transform.react.jsxInject + ';' + source
         }
 
         // Standardize on 'sourceMaps' as the key passed through to Webpack, so that


### PR DESCRIPTION
Add an entry that can customize the JSX helper, it is used in the same way as thevite, before the swc works, inject a custom JSX helper into all JSX/TSX files, and with the pragma and pragmaFrag can customize any desired parsing method

For example in vue3
```js
module: {
    rules: [
        {
            test: /\.(tsx|jsx)$/,
            exclude: /(node_modules|bower_components)/,
            use: {
                loader: "swc-loader",
                options: {
                    jsc: {
                        parser: {
                            syntax: "typescript"
                        },
                        transform: {
                            react: {
                                /** Use custom rendering functions, If you use the example of vue, it is */
                                pragma: 'h',
                                pragmaFrag: 'Fragment',
                                jsxInject:`import { h, Fragment } from 'vue'`
                            }
                        },
                    }
                }
            }
        }
    ];
}
```

In addition to vue, in some custom jsx rendering functions, this is more convenient and understandable;
For example: [tsx-dom](https://github.com/Lusito/tsx-dom)