### PR TITLE
Only stringify inputSourceMap if it's an object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function makeLoader() {
             delete loaderOptions.sourceMap;
         }
 
-        if (inputSourceMap) {
+        if (inputSourceMap && typeof inputSourceMap === "object") {
             inputSourceMap = JSON.stringify(inputSourceMap);
         }
 


### PR DESCRIPTION
There are cases where `inputSourceMap` might already be a string, so `JSON.stringify` might be unnecessary. In cases like these, it produces errors like the following:

```
ModuleBuildError: Module build failed (from ./node_modules/swc-loader/src/index.js):
Error: failed to process input file

Caused by:
    0: failed to read input source map from user-provided sourcemap
    1: bad json: invalid type: string "{\"version\":3,\"sources\":[...]}"
```

We can guard against this by only stringifying `inputSourceMap` if it's an object.