### PR TITLE
Add Webpack 4 Support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ function makeLoader() {
         const callback = this.async();
         const filename = this.resourcePath;
 
-        let loaderOptions = this.getOptions() || {};
+        let loaderOptions = (this.getOptions ? this.getOptions() : require('loader-utils').getOptions(this)) || {};
 
         // Standardize on 'sourceMaps' as the key passed through to Webpack, so that
         // users may safely use either one alongside our default use of
@@ -58,10 +58,10 @@ function makeLoader() {
         delete programmaticOptions.metadataSubscribers;
 
         // auto detect development mode
-        if (this.mode && programmaticOptions.jsc && programmaticOptions.jsc.transform 
-            && programmaticOptions.jsc.transform.react && 
+        if (this.mode && programmaticOptions.jsc && programmaticOptions.jsc.transform
+            && programmaticOptions.jsc.transform.react &&
             !Object.prototype.hasOwnProperty.call(programmaticOptions.jsc.transform.react, "development")) {
-                programmaticOptions.jsc.transform.react.development = this.mode === 'development'
+            programmaticOptions.jsc.transform.react.development = this.mode === 'development'
         }
 
         if (programmaticOptions.sourceMaps === "inline") {


### PR DESCRIPTION
This is the only change that is required to support Webpack 4, works great for me

I see `peerDependencies` for this library goes back to webpack 2, so I wanted to help make that a thing!

I wish the conditional could be evaluated only once for optimal perf, but it needed to be scoped for `this`. Perhaps I could set a flag the first time the conditional is evaluated:


```ts
let webpack5 = true;


function makeLoader() {
    return function (source, inputSourceMap) {
     // cheaper boolean conditional. 
     // if webpack5 is false the first time, don't check again
      if(webpack5 && 'getOptions' in this) {
         webpack5 = false
      }
      let loaderOptions = webpack5 ? this.getOptions() : require('loader-utils').getOptions(this)
    }
}

```

Do you have a way of benchmarking the webpack loader? Might be a negligible difference but worth considering

Note: Oddly, it looks like `github.dev` applied some formatting as well when I created this using this new approach, thought I'd try it